### PR TITLE
Solved issue where generate sequence function was excluding end point

### DIFF
--- a/source/efficiency and load regulation/configure_dc_power.py
+++ b/source/efficiency and load regulation/configure_dc_power.py
@@ -55,7 +55,7 @@ def generate_sequence(
             d = (stop - start) / (steps + 1)
             for i in range(steps + 2):
                 res.append((start + (i * d)))
-            return res
+            return res[1:-1]
     else:
         if with_end_points:
             r = 10 ** (1 / (steps))
@@ -70,7 +70,7 @@ def generate_sequence(
                 res.append(start * (r ** len(res)))
                 if res[-1] >= stop:
                     res[-1] = stop
-                    return res
+                    return res[1:-1]
     pass
 
 

--- a/source/efficiency and load regulation/configure_dc_power.py
+++ b/source/efficiency and load regulation/configure_dc_power.py
@@ -41,12 +41,13 @@ def generate_sequence(
         with_end_points: bool = True
 ) -> list[float]:
     res = []
-    if start >= stop or steps <= 0:
+    if start > stop or steps <= 0:
         return res
 
     if sweep_type == SweepType.Linear:
         if with_end_points:
-            d = (stop - start) / (steps - 1)
+            if (steps-1==0): d=0
+            else: d = (stop - start) / (steps - 1)
             for i in range(steps):
                 res.append((start + (i * d)))
             return res
@@ -57,7 +58,7 @@ def generate_sequence(
             return res
     else:
         if with_end_points:
-            r = 10 ** (1 / (steps - 1))
+            r = 10 ** (1 / (steps))
             while True:
                 res.append(start * (r ** len(res)))
                 if res[-1] >= stop:

--- a/source/efficiency and load regulation/configure_dc_power.py
+++ b/source/efficiency and load regulation/configure_dc_power.py
@@ -60,15 +60,15 @@ def generate_sequence(
             r = 10 ** (1 / (steps - 1))
             while True:
                 res.append(start * (r ** len(res)))
-                if res[-1] > stop:
-                    res.pop()
+                if res[-1] >= stop:
+                    res[-1] = stop
                     return res
         else:
             r = 10 ** (1 / (steps + 1))
             while True:
                 res.append(start * (r ** len(res)))
-                if res[-1] > stop:
-                    res.pop()
+                if res[-1] >= stop:
+                    res[-1] = stop
                     return res
     pass
 

--- a/source/line regulation/configure_dc_power.py
+++ b/source/line regulation/configure_dc_power.py
@@ -39,12 +39,13 @@ def generate_sequence(
         with_end_points: bool = True
 ) -> list[float]:
     res = []
-    if start >= stop or steps <= 0:
+    if start > stop or steps <= 0:
         return res
 
     if sweep_type == SweepType.Linear:
         if with_end_points:
-            d = (stop - start) / (steps - 1)
+            if (steps-1==0): d=0
+            else: d = (stop - start) / (steps - 1)
             for i in range(steps):
                 res.append((start + (i * d)))
             return res
@@ -55,7 +56,7 @@ def generate_sequence(
             return res
     else:
         if with_end_points:
-            r = 10 ** (1 / (steps - 1))
+            r = 10 ** (1 / (steps))
             while True:
                 res.append(start * (r ** len(res)))
                 if res[-1] >= stop:

--- a/source/line regulation/configure_dc_power.py
+++ b/source/line regulation/configure_dc_power.py
@@ -58,15 +58,15 @@ def generate_sequence(
             r = 10 ** (1 / (steps - 1))
             while True:
                 res.append(start * (r ** len(res)))
-                if res[-1] > stop:
-                    res.pop()
+                if res[-1] >= stop:
+                    res[-1] = stop
                     return res
         else:
             r = 10 ** (1 / (steps + 1))
             while True:
                 res.append(start * (r ** len(res)))
-                if res[-1] > stop:
-                    res.pop()
+                if res[-1] >= stop:
+                    res[-1] = stop
                     return res
     pass
 

--- a/source/line regulation/configure_dc_power.py
+++ b/source/line regulation/configure_dc_power.py
@@ -53,7 +53,7 @@ def generate_sequence(
             d = (stop - start) / (steps + 1)
             for i in range(steps + 2):
                 res.append((start + (i * d)))
-            return res
+            return res[1:-1]
     else:
         if with_end_points:
             r = 10 ** (1 / (steps))
@@ -68,7 +68,7 @@ def generate_sequence(
                 res.append(start * (r ** len(res)))
                 if res[-1] >= stop:
                     res[-1] = stop
-                    return res
+                    return res[1:-1]
     pass
 
 


### PR DESCRIPTION
Issue: - Generate Sequence Function was excluding end point while generating sequence in Logarithmic sweep mode.
Fix: - Added a check to include end point before returning the sequence
